### PR TITLE
refactor(mudmue-pick): best practices, async service layer, bug fixes

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -1,0 +1,120 @@
+# 🖐️ Mudmue Web — Project Structure
+
+โปรเจครวม mini-apps ส่วนตัว
+
+---
+
+## 📁 Directory Structure
+
+```
+mudmue-web/
+├── public/
+│
+├── src/
+│   ├── assets/                       # รูปภาพ, icons
+│   │
+│   ├── components/                   # Shared components
+│   │   ├── Loader.tsx
+│   │   ├── MudmueButton.tsx
+│   │   └── ...
+│   │
+│   ├── configs/
+│   │   └── router.tsx                # React Router config (createBrowserRouter)
+│   │
+│   ├── helpers/
+│   │   ├── formatDate.ts
+│   │   └── spinHelp.ts               # Logic รวม spin roulette
+│   │
+│   ├── pages/
+│   │   ├── MainLayout.tsx            # Root layout (Navbar + Outlet)
+│   │   ├── home/
+│   │   │   └── HomePage.tsx          # Landing page
+│   │   ├── leader-board/
+│   │   │   └── LeaderBoardPage.tsx
+│   │   │
+│   │   ├── mudmue-pick/              # 🎯 App 1 - จับคู่ผู้เล่น
+│   │   │   ├── MudmuePickPage.tsx    # Layout + Side/Tab menu
+│   │   │   ├── components/
+│   │   │   │   ├── TabMenu.tsx
+│   │   │   │   └── VSLabel.tsx
+│   │   │   ├── matchmaker/           # หน้า Spin Roulette
+│   │   │   │   ├── MudmueMatchmaker.tsx
+│   │   │   │   ├── Matchmaker.css
+│   │   │   │   ├── Roulette.css
+│   │   │   │   └── components/
+│   │   │   │       └── Roulette.tsx
+│   │   │   ├── dashboard/            # หน้าแสดง match ที่ยังไม่จบ
+│   │   │   │   ├── MudmueDashboard.tsx
+│   │   │   │   └── components/
+│   │   │   │       └── ScoreStepper.tsx
+│   │   │   ├── history/              # ประวัติ match ที่จบแล้ว
+│   │   │   │   └── MudmueHistory.tsx
+│   │   │   └── profile/              # จัดการ player profile
+│   │   │       └── MudmueProfile.tsx
+│   │   │
+│   │   └── mudmue-chim/              # 🗺️ App 2 - แผนที่ + รีวิวร้านอาหาร (Phase ถัดไป)
+│   │
+│   ├── services/
+│   │   ├── matchService.ts           # CRUD match (localStorage)
+│   │   ├── profileService.ts         # CRUD player profile (localStorage)
+│   │   └── mockDashboardData.ts      # Mock data
+│   │
+│   ├── main.tsx                      # Entry point
+│   └── index.css
+│
+├── index.html
+├── vite.config.ts
+├── tailwind.config.ts
+├── tsconfig.json
+├── package.json
+└── PROJECT_STRUCTURE.md
+```
+
+---
+
+## 🚀 Apps Overview
+
+### 🎯 Mudmue Pick
+> จับคู่ผู้เล่นแบบสุ่มด้วย Roulette
+
+| Phase | Feature |
+|-------|---------|
+| Phase 1 | Spin roulette จับคู่แบบสุ่ม, สร้าง match list, กด Complete เมื่อจบ |
+| Phase 2 | จับคู่ตามฝีมือ โดยดูจากประวัติที่เคยบันทึกไว้ |
+
+**Data Model**
+```
+Player        { id, name, skill? }
+MatchSession  { id, date, players[], status }
+Match         { id, sessionId, player1, player2, completed, winner? }
+```
+
+---
+
+### 🗺️ Mudmue Chim
+> แผนที่ปักหมุดและรีวิวร้านอาหาร
+
+| Feature | รายละเอียด |
+|---------|-----------|
+| แผนที่ | แสดงตำแหน่งปัจจุบันผ่าน GPS |
+| ปักหมุด | เพิ่มร้านอาหารที่สนใจลงแผนที่ |
+| รีวิว | รีวิวร้านที่เคยไป พร้อมคะแนนและรูปภาพ |
+
+**Data Model**
+```
+Place   { id, name, lat, lng, category, addedAt }
+Review  { id, placeId, rating, comment, images[], visitedAt }
+```
+
+---
+
+## 🛠️ Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Framework | React 18 + Vite |
+| Routing | React Router v6 |
+| Styling | Tailwind CSS + DaisyUI + styled-components |
+| Animation | Framer Motion |
+| Storage | localStorage (Phase 1) |
+| Language | TypeScript |

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.20",
+        "concurrently": "^8.0.0",
         "daisyui": "^4.12.14",
         "eslint": "^9.15.0",
         "eslint-plugin-react-hooks": "^5.0.0",
@@ -266,6 +267,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1961,6 +1971,78 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1999,6 +2081,48 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/concurrently": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
+      "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "date-fns": "^2.30.0",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "spawn-command": "0.0.2",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": "^14.13.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2091,6 +2215,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/daisyui"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -2581,6 +2721,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -2916,6 +3065,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -3513,6 +3668,15 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -3614,6 +3778,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -3657,6 +3830,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -3685,6 +3870,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/spawn-command": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
+      "dev": true
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -4007,6 +4198,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4357,6 +4557,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -4373,6 +4582,74 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "postcss src/index.css -o src/style.css --watch & vite",
+    "dev": "concurrently \"npx postcss src/index.css -o src/style.css --watch\" \"vite\"",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"
@@ -24,6 +24,7 @@
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
+    "concurrently": "^8.0.0",
     "daisyui": "^4.12.14",
     "eslint": "^9.15.0",
     "eslint-plugin-react-hooks": "^5.0.0",

--- a/src/helpers/spinHelp.ts
+++ b/src/helpers/spinHelp.ts
@@ -1,4 +1,4 @@
-import { PlayerProps } from "../pages/mudmue-pick/matchmaker/MudmueMatchmaker";
+import { PlayerProps } from "../types/player";
 
 export const  spinRoundsWithCarryOver = (pool: PlayerProps[], perRound: number, nRounds: number): PlayerProps[][] => {
     let carry: PlayerProps[] = [];   // เก็บคนตกค้าง

--- a/src/pages/mudmue-pick/components/TabMenu.tsx
+++ b/src/pages/mudmue-pick/components/TabMenu.tsx
@@ -61,7 +61,7 @@ export function TabMenu({
                             onChange={() => onChangeTab(tab.path)}
                         />
                         <TabLabel
-                            htmlFor={`tab_${tab.path}`}
+                            htmlFor={`tab_${tab.path}_${idx}`}
                             active={activeTab === tab.path}
                             onClick={() => onChangeTab(tab.path)}
                         >

--- a/src/pages/mudmue-pick/components/VSLabel.tsx
+++ b/src/pages/mudmue-pick/components/VSLabel.tsx
@@ -19,7 +19,7 @@ export const VSLabel = (props: VSLabelProps) => {
     const { size = 32 } = props;
 
     return (
-        <div className={`font-noto font-bold text-[${size}px] relative w-10 h-12`}>
+        <div className="font-noto font-bold relative w-10 h-12" style={{ fontSize: size }}>
             <VLabel>V</VLabel>
             <SLabel>S</SLabel>
         </div>

--- a/src/pages/mudmue-pick/dashboard/MudmueDashboard.tsx
+++ b/src/pages/mudmue-pick/dashboard/MudmueDashboard.tsx
@@ -1,4 +1,4 @@
-import { MatchDataType, PlayerDataType, loadMatchesWithFilter, updateMatch } from "../../../services/matchService.ts";
+import { MatchDataType, PlayerDataType, loadMatchesWithFilterAsync, updateMatchAsync } from "../../../services/matchService.ts";
 import { getDetailProfile, getDetailProfileByField } from "../../../services/profileService.ts";
 import styled, { keyframes } from "styled-components";
 import { useEffect, useState } from "react";
@@ -11,11 +11,7 @@ import IconShuttleCockBlue from "../../../assets/icon-shuttlecock-blue.png";
 import IconShuttleCockRed from "../../../assets/icon-shuttlecock-red.png";
 import { ScoreStepper } from "./components/ScoreStepper.tsx";
 import { VSLabel } from "../components/VSLabel.tsx";
-
-const breakpoints = {
-    tablet: 900,
-    mobile: 600,
-};
+import { breakpoints } from "../../../styles/breakpoints.ts";
 
 const MudmueDashboardListContainer = styled.div`
     width: 100%;
@@ -168,18 +164,14 @@ const FightPunchRight = styled.img`
 `;
 export const MudmueDashboard = () => {
     const [data, setData] = useState<MatchDataType[]>();
-    const [currentEditData] = useState<MatchDataType[]>([]);
     const [fightingMatchIds, setFightingMatchIds] = useState<number[]>([]);
 
-    const resolveIsEdit = (id: number) => currentEditData.some((m) => m.id === id);
-    const matchToRender = (d: MatchDataType) => (resolveIsEdit(d.id) ? currentEditData.find((m) => m.id === d.id) : d);
+    const matchToRender = (d: MatchDataType) => d;
 
     const resolvePlayerLabelLeftSide = (players: PlayerDataType[]) => {
-        // return players.filter((player) => player.team === "red").sort((a, b) => a.position - b.position);
         return players.filter((player) => player.team === "red").sort((a, b) => a.position - b.position);
     };
     const resolvePlayerLabelRightSide = (players: PlayerDataType[]) => {
-        // return players.filter((player) => player.team === "blue").sort((a, b) => a.position - b.position);
         return players.filter((player) => player.team === "blue").sort((a, b) => a.position - b.position);
     };
     const handleScoreChange = (id: number, team: "blue" | "red", score: number) => {
@@ -240,94 +232,48 @@ export const MudmueDashboard = () => {
         // ฝั่ง red เสิร์ฟตรงข้าม index
         return index !== shouldServeIndex;
     };
-    // const handleClickEdit = (id: number) => {
-    //     const matchData = data.find((d) => d.id === id);
-    //     if (matchData) {
-    //         setCurrentEditData([...currentEditData, matchData]);
-    //         // เปิด modal หรือทำอย่างอื่นเพื่อแก้ไขข้อมูล
-    //         console.log("Editing match data:", matchData);
-    //     }
-    // };
-    // const handleClickSaveEdit = (id: number) => {
-    //     const editMatch = currentEditData.find((m) => m.id === id);
-    //     if (editMatch) {
-    //         setData((prevData) => prevData.map((d) => (d.id === id ? editMatch : d)));
-    //         setCurrentEditData((prev) => prev.filter((m) => m.id !== id));
-    //     }
-    // };
-    // const handleClickCancelEdit = (id: number) => {
-    //     setCurrentEditData((prev) => prev.filter((m) => m.id !== id));
-    // }; // NOTE : Phase 2 edit available
 
-    const handleClickCompleteMatch = (id: number) => {
+    // NOTE: Phase 2 — edit match handlers will be added here
+
+    const handleClickCompleteMatch = async (id: number) => {
         const match = data?.find((d) => d.id === id);
         if (!match) return;
-        console.log("Completing match id:", id);
-        console.log("Match data:", match);
 
-        // รวมคะแนนแต่ละทีม
-        const redScore = match.player.filter((p) => p.team === "red")[0].score ?? 0;
-        const blueScore = match.player.filter((p) => p.team === "blue")[0].score ?? 0;
+        const redScore = match.player.find((p) => p.team === "red")?.score ?? 0;
+        const blueScore = match.player.find((p) => p.team === "blue")?.score ?? 0;
 
-        // หาผู้ชนะ
         let winner: string = "tiled";
         if (redScore > blueScore) winner = "red";
         else if (blueScore > redScore) winner = "blue";
-        console.log("Winner:", winner);
-        // เซฟลง localStorage/history service
-        updateMatch(id, match.player, match.serviceSide!, winner);
-        // setData(updatedData);
+
+        await updateMatchAsync(id, match.player, match.serviceSide!, winner);
         setFightingMatchIds((prev) => [...prev, id]);
 
-        // 2. หลังจาก fade-out (ระยะเวลาเช่น 500ms) ค่อย update list โดยโหลด filter ใหม่
-        setTimeout(() => {
+        setTimeout(async () => {
             setFightingMatchIds((prev) => prev.filter((_id) => _id !== id));
-            setData(loadMatchesWithFilter({ finished: false }));
+            const updated = await loadMatchesWithFilterAsync({ finished: false });
+            setData(updated);
         }, 1000);
     };
 
     useEffect(() => {
-        setData(loadMatchesWithFilter({ finished: false, orderBy: "createDate", orderDirection: "desc" }));
+        let mounted = true;
+        loadMatchesWithFilterAsync({ finished: false, orderBy: "createDate", orderDirection: "desc" }).then((result) => {
+            if (mounted) setData(result);
+        });
+        return () => { mounted = false; };
     }, []);
     return (
         <MudmueDashboardContainer>
             <MudmueDashboardFilterContainer>
                 <div className="flex flex-row gap-4">
-                    {/* <MudmueButton
-                        size="small"
-                        theme="secondary"
-                        onClick={() => {
-                            setData([]);
-                        }}
-                    >
-                        test reset data
-                    </MudmueButton>
-                    <MudmueButton
-                        size="small"
-                        onClick={() => {
-                            setData(getMockMatches());
-                        }}
-                    >
-                        test add mock data
-                    </MudmueButton> */}
+                    {/* NOTE: Phase 2 — filter/add controls will go here */}
                 </div>
                 <div className="flex flex-row gap-4">
-                    {/* <button className="btn btn-circle font-noto " onClick={() => {}}>
-                        <img
-                            src={IconMudVsMud}
-                            alt="random-player"
-                            width={46}
-                            height={46}
-                        />
-                        random
-                    </button> */}
-                    {/* <button className="btn btn-circle font-noto " onClick={() => {}}>
-                        <img src={IconPlusBlue} alt="add-player" />
-                    </button> */}{" "}
-                    {/* NOTE: wait for phase 2 edit match */}
+                    {/* NOTE: Phase 2 — action buttons will go here */}
                 </div>
             </MudmueDashboardFilterContainer>
-            {/* <div className="w-[90%] h-[1px] bg-[#0000ff] my-4"></div> Note: wait for phase 2 edit match */}
+            {/* <div className="w-[90%] h-[1px] bg-[#0000ff] my-4"></div> */}
             <MudmueDashboardListContainer>
                 {data?.length === 0 ? (
                     <div className="w-full h-[840px] flex items-center justify-center flex-col gap-2">
@@ -345,16 +291,11 @@ export const MudmueDashboard = () => {
                                 <div className="card w-full bg-base-100 shadow-lg sm:px-0 md:px-2">
                                     <PlayerCardContainer>
                                         <div className="flex flex-row justify-end items-center w-[200px] lg:w-[360px] gap-4 lg:justify-between">
-                                            {/* {d.player.length ? `${d.player.find((p) => p.team === "blue")!.score}` : "-"} */}
-                                            {currentEditData.find((match) => match.id === d.id) ? (
-                                                <div></div>
-                                            ) : (
-                                                <ScoreStepper
-                                                    team="red"
-                                                    score={d.player.find((p) => p.team === "red")!.score}
-                                                    callback={(s) => handleScoreChange(d.id, "red", s)}
-                                                />
-                                            )}
+                                            <ScoreStepper
+                                                team="red"
+                                                score={d.player.find((p) => p.team === "red")!.score}
+                                                callback={(s) => handleScoreChange(d.id, "red", s)}
+                                            />
 
                                             <PlayerCardDisplay>
                                                 {resolvePlayerLabelLeftSide(matchToRender(d)!.player).map(
@@ -453,51 +394,14 @@ export const MudmueDashboard = () => {
                                                     )
                                                 )}
                                             </PlayerCardDisplay>
-                                            {/* {d.player.length ? `${d.player.find((p) => p.team === "red")!.score}` : "-"} */}
-                                            {currentEditData.find((match) => match.id === d.id) ? (
-                                                <div></div>
-                                            ) : (
-                                                <ScoreStepper
-                                                    team="blue"
-                                                    score={d.player.find((p) => p.team === "blue")!.score}
-                                                    callback={(s) => handleScoreChange(d.id, "blue", s)}
-                                                />
-                                            )}
+                                            <ScoreStepper
+                                                team="blue"
+                                                score={d.player.find((p) => p.team === "blue")!.score}
+                                                callback={(s) => handleScoreChange(d.id, "blue", s)}
+                                            />
                                         </div>
                                         <div className="absolute bottom-2 right-2 h-full flex flex-col items-end gap-4">
-                                            {/* {currentEditData.some((match) => match.id === d.id) ? (
-                                    <div className="flex flex-row gap-2">
-                                        <img
-                                            src={IconSave}
-                                            alt="save-edit"
-                                            className="cursor-pointer"
-                                            title="Save"
-                                            onClick={() => handleClickSaveEdit(d.id)}
-                                            width={32}
-                                            height={32}
-                                        />
-                                        <img
-                                            src={IconCancel}
-                                            alt="cancel-edit"
-                                            className="cursor-pointer"
-                                            title="Cancel"
-                                            onClick={() => handleClickCancelEdit(d.id)}
-                                            width={32}
-                                            height={32}
-                                        />
-                                    </div>
-                                ) : (
-                                    <img
-                                        src={IconEdit}
-                                        alt="edit-icon"
-                                        className="cursor-pointer"
-                                        title="Edit Match"
-                                        onClick={() => handleClickEdit(d.id)}
-                                        width={32}
-                                        height={32}
-                                    />
-                                )} */}{" "}
-                                            {/* NOTE  : Phase 2 edit available */}
+                                            {/* NOTE: Phase 2 — edit match icon will go here */}
                                             <img
                                                 src={IconComplete}
                                                 alt="complete-match"

--- a/src/pages/mudmue-pick/dashboard/components/ScoreStepper.tsx
+++ b/src/pages/mudmue-pick/dashboard/components/ScoreStepper.tsx
@@ -33,11 +33,12 @@ const trophyGrow = keyframes`
   100% { transform: scale(0.8); }
 `;
 
-const AnimatedTrophy = styled.img`
+const AnimatedTrophy = styled.img<{ faded?: boolean }>`
     animation: ${trophyGrow} 1.2s ease infinite;
     position: relative;
     width: 129px;
     height: 129px;
+    opacity: ${({ faded }) => (faded ? 0.35 : 1)};
 `;
 
 interface ScoreStepperProps {
@@ -70,7 +71,7 @@ export const ScoreStepper = (props: ScoreStepperProps) => {
                 <span className="relative z-[2] ">{score}</span>
                 {showTrophy && (
                     <TrophyContainer>
-                        <AnimatedTrophy src={IconTrophy} alt="trophy" />
+                        <AnimatedTrophy src={IconTrophy} alt="trophy" faded={isDisplay} />
                     </TrophyContainer>
                 )}
             </div>

--- a/src/pages/mudmue-pick/history/MudmueHistory.tsx
+++ b/src/pages/mudmue-pick/history/MudmueHistory.tsx
@@ -1,9 +1,8 @@
 import {
     MatchDataType,
     PlayerDataType,
-    createMatch,
-    loadMatchesWithFilter,
-    saveHistories,
+    createMatchAsync,
+    loadMatchesWithFilterAsync,
 } from "../../../services/matchService.ts";
 import { getDetailProfile, getDetailProfileByField } from "../../../services/profileService.ts";
 import { useEffect, useState } from "react";
@@ -13,12 +12,8 @@ import IconShuttleCockBlue from "../../../assets/icon-shuttlecock-blue.png";
 import IconShuttleCockRed from "../../../assets/icon-shuttlecock-red.png";
 import { ScoreStepper } from "../dashboard/components/ScoreStepper.tsx";
 import { VSLabel } from "../components/VSLabel.tsx";
+import { breakpoints } from "../../../styles/breakpoints.ts";
 import styled from "styled-components";
-
-const breakpoints = {
-    tablet: 900,
-    mobile: 600,
-};
 
 const DashboardContainer = styled.div`
     width: 100%;
@@ -66,10 +61,14 @@ const ServiceSideRightIcon = styled.img`
 
 export const MudmueHistory = () => {
     const [data, setData] = useState<MatchDataType[]>();
-    const [currentEditData] = useState<MatchDataType[]>([]);
+    const [toast, setToast] = useState<string | null>(null);
 
-    const resolveIsEdit = (id: number) => currentEditData.some((m) => m.id === id);
-    const matchToRender = (d: MatchDataType) => (resolveIsEdit(d.id) ? currentEditData.find((m) => m.id === d.id) : d);
+    const showToast = (msg: string) => {
+        setToast(msg);
+        setTimeout(() => setToast(null), 2500);
+    };
+
+    const matchToRender = (d: MatchDataType) => d;
 
     const resolvePlayerLabelLeftSide = (players: PlayerDataType[]) => {
         return players.filter((player) => player.team === "red").sort((a, b) => a.position - b.position);
@@ -77,17 +76,17 @@ export const MudmueHistory = () => {
     const resolvePlayerLabelRightSide = (players: PlayerDataType[]) => {
         return players.filter((player) => player.team === "blue").sort((a, b) => a.position - b.position);
     };
-    const handleRematch = (oldMatch: MatchDataType) => {
+    const handleRematch = async (oldMatch: MatchDataType) => {
         const players = oldMatch.player.map((p, idx) => ({
             ...p,
             score: 0,
             position: p.position ?? idx,
         }));
         const serviceSide = Math.random() < 0.5 ? "red" : "blue";
-        const newList = createMatch(players, serviceSide);
-        saveHistories(newList);
-        setData(loadMatchesWithFilter({ finished: true, orderBy: "updateDate", orderDirection: "desc" }));
-        alert("สร้างแมตช์ใหม่ใน Dashboard เรียบร้อยแล้ว!");
+        await createMatchAsync(players, serviceSide);
+        const updated = await loadMatchesWithFilterAsync({ finished: true, orderBy: "updateDate", orderDirection: "desc" });
+        setData(updated);
+        showToast("สร้างแมตช์ใหม่ใน Dashboard เรียบร้อยแล้ว!");
     };
 
     const resolveDisplayScoreIcon = (
@@ -96,75 +95,50 @@ export const MudmueHistory = () => {
         index: number,
         team: "blue" | "red"
     ): boolean => {
-        if (type === "single") {
-            return true;
-        }
-
-        // type === "duo"
+        if (type === "single") return true;
         const isEven = score % 2 === 0;
-
         const shouldServeIndex = isEven ? 0 : 1;
-
-        // ฝั่ง blue เสิร์ฟตรง index เลย
-        if (team === "blue") {
-            return index === shouldServeIndex;
-        }
-
-        // ฝั่ง red เสิร์ฟตรงข้าม index
+        if (team === "blue") return index === shouldServeIndex;
         return index !== shouldServeIndex;
     };
 
-    // const handleClickEdit = (id: number) => {
-    //     const matchData = data.find((d) => d.id === id);
-    //     if (matchData) {
-    //         setCurrentEditData([...currentEditData, matchData]);
-    //         // เปิด modal หรือทำอย่างอื่นเพื่อแก้ไขข้อมูล
-    //         console.log("Editing match data:", matchData);
-    //     }
-    // };
-    // const handleClickSaveEdit = (id: number) => {
-    //     const editMatch = currentEditData.find((m) => m.id === id);
-    //     if (editMatch) {
-    //         setData((prevData) => prevData.map((d) => (d.id === id ? editMatch : d)));
-    //         setCurrentEditData((prev) => prev.filter((m) => m.id !== id));
-    //     }
-    // };
-    // const handleClickCancelEdit = (id: number) => {
-    //     setCurrentEditData((prev) => prev.filter((m) => m.id !== id));
-    // }; // NOTE : Phase 2 edit available
+    // NOTE: Phase 2 — edit match handlers will be added here
+
     useEffect(() => {
-        setData(loadMatchesWithFilter({ finished: true, orderBy: "updateDate", orderDirection: "desc" }));
+        let mounted = true;
+        loadMatchesWithFilterAsync({ finished: true, orderBy: "updateDate", orderDirection: "desc" }).then((result) => {
+            if (mounted) setData(result);
+        });
+        return () => { mounted = false; };
     }, []);
     return (
         <DashboardContainer>
+            {toast && (
+                <div className="toast toast-top toast-center z-50">
+                    <div className="alert alert-success font-noto">
+                        <span>{toast}</span>
+                    </div>
+                </div>
+            )}
+            {(!data || data.length === 0) && (
+                <div className="w-full flex items-center justify-center py-16">
+                    <p className="font-noto text-[20px] text-gray-400">ยังไม่มีประวัติการแข่งขัน</p>
+                </div>
+            )}
             {data?.map((d) => (
                 <div key={d.id} className="w-full px-16">
                     <div className="card w-full bg-base-100 shadow-lg sm:px-0 md:px-2 h-[182px]">
                         <PlayerCardContainer>
                             <div className="flex flex-row justify-end items-center w-[200px] lg:w-[360px] gap-4 lg:justify-between relative">
-                                {/* <TrophyLeftContainer mode={d.player.length === 2 ? "single" : "duo"}>
-                                    {d.winner === "red" && (
-                                        <>
-                                            <AnimatedTrophy src={IconTrophy}></AnimatedTrophy>
-                                        </>
-                                    )}
-                                </TrophyLeftContainer> */}
-                                {/* {d.player.length ? `${d.player.find((p) => p.team === "blue")!.score}` : "-"} */}
-                                {currentEditData.find((match) => match.id === d.id) ? (
-                                    <div></div>
-                                ) : (
-                                    <ScoreStepper
-                                        className="z-[1]"
-                                        team="red"
-                                        score={d.player.find((p: PlayerDataType) => p.team === "red")!.score}
-                                        callback={() => {}}
-                                        showTrophy={d.winner === "red"}
-                                        isDisplay
-                                    />
-                                )}
-                                {/* <TrophyContainer>
-                                    {d.winner === "red" && <img src={IconTrophy}></img>}
-                                </TrophyContainer> */}
+                                {/* TrophyLeftContainer reserved for Phase 2 */}
+                                <ScoreStepper
+                                    className="z-[1]"
+                                    team="red"
+                                    score={d.player.find((p: PlayerDataType) => p.team === "red")!.score}
+                                    callback={() => {}}
+                                    showTrophy={d.winner === "red"}
+                                    isDisplay
+                                />
                                 <PlayerCardDisplay>
                                     {resolvePlayerLabelLeftSide(matchToRender(d)!.player).map(
                                         (p: PlayerDataType, index: number) => (
@@ -254,62 +228,17 @@ export const MudmueHistory = () => {
                                         )
                                     )}
                                 </PlayerCardDisplay>
-                                {/* <TrophyContainer>
-                                    {d.winner === "blue" && <img src={IconTrophy}></img>}
-                                </TrophyContainer> */}
-                                {/* {d.player.length ? `${d.player.find((p) => p.team === "red")!.score}` : "-"} */}
-                                {currentEditData.find((match) => match.id === d.id) ? (
-                                    <div></div>
-                                ) : (
-                                    <ScoreStepper
-                                        team="blue"
-                                        score={d.player.find((p: PlayerDataType) => p.team === "blue")!.score}
-                                        callback={() => {}}
-                                        isDisplay
-                                        showTrophy={d.winner === "blue"}
-                                    />
-                                )}
-                                {/* <TrophyRightContainer mode={d.player.length === 2 ? "single" : "duo"}>
-                                    {d.winner === "blue" && (
-                                        <>
-                                            <AnimatedTrophy src={IconTrophy}></AnimatedTrophy>
-                                        </>
-                                    )}
-                                </TrophyRightContainer> */}
+                                {/* TrophyRightContainer reserved for Phase 2 */}
+                                <ScoreStepper
+                                    team="blue"
+                                    score={d.player.find((p: PlayerDataType) => p.team === "blue")!.score}
+                                    callback={() => {}}
+                                    isDisplay
+                                    showTrophy={d.winner === "blue"}
+                                />
                             </div>
                             <div className="absolute bottom-2 right-2 h-full flex flex-col items-end gap-4">
-                                {/* {currentEditData.some((match) => match.id === d.id) ? (
-                                    <div className="flex flex-row gap-2">
-                                        <img
-                                            src={IconSave}
-                                            alt="save-edit"
-                                            className="cursor-pointer"
-                                            title="Save"
-                                            onClick={() => handleClickSaveEdit(d.id)}
-                                            width={32}
-                                            height={32}
-                                        />
-                                        <img
-                                            src={IconCancel}
-                                            alt="cancel-edit"
-                                            className="cursor-pointer"
-                                            title="Cancel"
-                                            onClick={() => handleClickCancelEdit(d.id)}
-                                            width={32}
-                                            height={32}
-                                        />
-                                    </div>
-                                ) : (
-                                    <img
-                                        src={IconEdit}
-                                        alt="edit-icon"
-                                        className="cursor-pointer"
-                                        title="Edit Match"
-                                        onClick={() => handleClickEdit(d.id)}
-                                        width={32}
-                                        height={32}
-                                    />
-                                )} */}{" "}
+                                {/* NOTE: Phase 2 — edit match icon will go here */}
                                 {/* NOTE  : Phase 2 edit available */}
                                 <img
                                     src={IconReplay}

--- a/src/pages/mudmue-pick/matchmaker/MudmueMatchmaker.tsx
+++ b/src/pages/mudmue-pick/matchmaker/MudmueMatchmaker.tsx
@@ -1,25 +1,23 @@
 import "./Roulette.css";
 import "./Matchmaker.css";
 
-import { PlayerProfile, loadProfiles } from "../../../services/profileService";
-import React, { useEffect, useState } from "react";
-import { createMatch, loadHistories, saveHistories } from "../../../services/matchService";
+import { PlayerProfile, loadProfilesAsync } from "../../../services/profileService";
+import React, { useEffect, useRef, useState } from "react";
 
 import IconBin from "../../../assets/bin.svg";
 import IconHide from "../../../assets/icon-hide.png";
 import IconReset from "../../../assets/icon-reset.png";
 import IconUnhide from "../../../assets/icon-unhide.png";
 import { MudmueButton } from "../../../components/MudmueButton";
+import { PlayerProps } from "../../../types/player";
 import { Roulette } from "./components/Roulette";
 import { VSLabel } from "../components/VSLabel";
+import { breakpoints } from "../../../styles/breakpoints";
+import { createMatchAsync } from "../../../services/matchService";
 import { spinRoundsWithCarryOver } from "../../../helpers/spinHelp";
 import styled from "styled-components";
 import { useLoader } from "../../../components/Loader";
 
-const breakpoints = {
-    tablet: 900,
-    mobile: 600,
-};
 const MudmueMatchmakerContainer = styled.div`
     width: 100%;
     height: 100%;
@@ -41,13 +39,6 @@ const MudmueMatchmakerPlayerContainer = styled.div`
     height: 200px;
     // height: 20%;
 `;
-export interface PlayerProps {
-    id: number;
-    name: string;
-    displayName?: string;
-    hide: boolean;
-    uuid: string;
-}
 interface RoundResultMatchmakerProps {
     id: number;
     players: PlayerProps[];
@@ -71,6 +62,8 @@ const initialPlayers = (isReset: boolean) => {
 };
 export const MudmueMatchmaker = () => {
     const { showLoader, hideLoader } = useLoader();
+    const resultModalRef = useRef<HTMLDialogElement>(null);
+    const profilePickerRef = useRef<HTMLDialogElement>(null);
     const [players, setPlayers] = useState<PlayerProps[]>(initialPlayers(false));
     const [results, setResults] = useState<RoundResultMatchmakerProps[]>([]);
     const [spinning, setSpinning] = useState(false);
@@ -92,23 +85,12 @@ export const MudmueMatchmaker = () => {
     };
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const { name, value, type, checked } = e.target;
-        console.log("handleChange", { name, value, type, checked });
-        // กำหนดชื่อ field ที่ต้องการแปลงเป็น number
         const numberFields = ["playerAmount", "times"];
         let newValue: string | number | boolean;
         if (type === "checkbox") {
             newValue = checked;
         } else if (type === "radio" || numberFields.includes(name)) {
             newValue = Number(value);
-            if (name === "playerAmount" && value === "4") {
-                if (players.length < 4) {
-                    setPlayers([
-                        ...players,
-                        { id: 2, name: "Player 3", hide: false, uuid: "" },
-                        { id: 3, name: "Player 4", hide: false, uuid: "" },
-                    ]);
-                }
-            }
         } else {
             newValue = value;
         }
@@ -127,15 +109,7 @@ export const MudmueMatchmaker = () => {
         setPlayerName("");
     };
     const handleClickRemovePlayer = (p: PlayerProps) => {
-        setPlayers((prevPlayers) => {
-            const index = prevPlayers.indexOf(p);
-            if (index !== -1) {
-                const newPlayers = [...prevPlayers];
-                newPlayers.splice(index, 1);
-                return newPlayers;
-            }
-            return prevPlayers;
-        });
+        setPlayers((prev) => prev.filter((player) => player.id !== p.id));
     };
     const handleClickToggleHidePlayer = (p: PlayerProps) => {
         setPlayers((prevPlayers) => {
@@ -147,20 +121,18 @@ export const MudmueMatchmaker = () => {
         setResults([]);
         setIsShowResultModal(false);
         if (option.hideFromList) {
-            // รวมชื่อ player ทั้งหมดที่อยู่ในผลลัพธ์
             const resultNames = results.flatMap((round) => round.players.map((p) => p.name));
             setPlayers((prevPlayers) =>
                 prevPlayers.map((player) => (resultNames.includes(player.name) ? { ...player, hide: true } : player))
             );
         }
-        (document.getElementById("match_result") as HTMLDialogElement).close();
+        resultModalRef.current?.close();
     };
     // -- ใช้วิธี แบ่งคนเป็น pool แล้วสุ่มจาก pool ออกมาเท่ากับ optionPlayerAmount ในกรณีที่คนเหลือก็จะเอาคนคนเล่นมา random ใหม่
     // --(ถ้าอยาก random แล้ว recycle pool จนครบจำนวนรอบที่ user เลือก
     const spin = () => {
         setIsCloseResultModal(false);
         const pool = players.filter((p) => !p.hide);
-        // --- สุ่ม random ผลลัพธ์ n รอบ ด้วย recycle pool
         const groupList = spinRoundsWithCarryOver(pool, option.playerAmount, option.times);
         const allResults: RoundResultMatchmakerProps[] = groupList.map((group: PlayerProps[], i: number) => ({
             id: results.length + i + 1,
@@ -169,40 +141,34 @@ export const MudmueMatchmaker = () => {
 
         setResults((prev) => [...prev, ...allResults]);
 
-        // Modal แสดงผลลัพธ์ - เหมือนเดิม
-        if (!option.skipAnimation && option.times == 1) {
+        if (!option.skipAnimation && option.times === 1) {
             setSpinning(true);
             setTimeout(() => {
                 setSpinning(false);
                 setIsShowResultModal(true);
-                (document.getElementById("match_result") as HTMLDialogElement).showModal();
+                resultModalRef.current?.showModal();
             }, 4000);
         } else {
             showLoader();
             setTimeout(() => {
                 hideLoader();
                 setIsShowResultModal(true);
-                (document.getElementById("match_result") as HTMLDialogElement).showModal();
+                resultModalRef.current?.showModal();
             }, 1500);
         }
     };
     const openProfileModal = () => {
-        setProfileList(loadProfiles());
-        setSelectedProfiles([]); // reset
-        (document.getElementById("profile_picker") as HTMLDialogElement).showModal();
+        loadProfilesAsync().then((list) => {
+            setProfileList(list);
+            setSelectedProfiles([]);
+            profilePickerRef.current?.showModal();
+        });
     };
-    const closeProfileModal = () => (document.getElementById("profile_picker") as HTMLDialogElement).close();
+    const closeProfileModal = () => profilePickerRef.current?.close();
     const handleAddProfiles = () => {
-        console.log("selectedProfiles uuids:", selectedProfiles);
-        console.log("profileList:", profileList);
-        const toAdd = profileList.filter((p) => selectedProfiles.includes(p.uuid));
-        console.log("toAdd after filter:", toAdd);
-
         const currentUuids = players.map((p) => p.uuid);
-        console.log("current player uuids:", currentUuids);
-
-        const addList = toAdd
-            .filter((p) => !currentUuids.includes(p.uuid))
+        const addList = profileList
+            .filter((p) => selectedProfiles.includes(p.uuid) && !currentUuids.includes(p.uuid))
             .map((p, index) => ({
                 id: players.length + index,
                 name: p.name,
@@ -210,8 +176,6 @@ export const MudmueMatchmaker = () => {
                 hide: false,
                 uuid: p.uuid,
             }));
-        console.log("addList (will add to players):", addList);
-
         setPlayers([...players, ...addList]);
         closeProfileModal();
     };
@@ -229,11 +193,8 @@ export const MudmueMatchmaker = () => {
     const savePlayersToSession = (players: PlayerProps[]) => {
         sessionStorage.setItem("mudmue_players", JSON.stringify(players));
     };
-    const handleClickConfirmResult = () => {
-        console.log("Confirming result...");
-        let historyList = loadHistories();
-
-        results.forEach((group) => {
+    const handleClickConfirmResult = async () => {
+        const createPromises = results.map((group) => {
             const half = group.players.length / 2;
             const redTeam = group.players.slice(0, half).map((p, i) => ({
                 name: p.name,
@@ -249,17 +210,13 @@ export const MudmueMatchmaker = () => {
                 score: 0,
                 position: i,
             }));
-            const players = [...redTeam, ...blueTeam];
-
+            const matchPlayers = [...redTeam, ...blueTeam];
             const serviceSide = Math.random() < 0.5 ? "red" : "blue";
-
-            historyList = createMatch( players, serviceSide);
+            return createMatchAsync(matchPlayers, serviceSide);
         });
-
-        saveHistories(historyList);
-
+        await Promise.all(createPromises);
         setIsShowResultModal(false);
-        (document.getElementById("match_result") as HTMLDialogElement).close();
+        resultModalRef.current?.close();
     };
 
     useEffect(() => {
@@ -398,6 +355,12 @@ export const MudmueMatchmaker = () => {
                             >
                                 <span className="font-noto text-[18px]">Random</span>
                             </MudmueButton>
+                            {players.filter((p) => !p.hide).length < option.playerAmount && (
+                                <span className="font-noto text-[12px] text-gray-400 mt-1">
+                                    Need {option.playerAmount} available players
+                                    (currently {players.filter((p) => !p.hide).length})
+                                </span>
+                            )}
                         </div>
                     </div>
                 </div>
@@ -490,7 +453,7 @@ export const MudmueMatchmaker = () => {
                     </ul>
                 </div>
             </MudmueMatchmakerPlayerContainer>
-            <dialog id="match_result" className="modal">
+            <dialog ref={resultModalRef} className="modal">
                 <div
                     className={`modal-box w-10/12 lg:w-8/12 max-w-5xl flex flex-col items-center ${
                         isShowResultModal ? "animate-fade-in" : ""
@@ -586,11 +549,11 @@ export const MudmueMatchmaker = () => {
                     </span>
                 </div>
             </dialog>
-            <dialog id="profile_picker" className="modal">
+            <dialog ref={profilePickerRef} className="modal">
                 <div className="modal-box">
                     <button
                         className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
-                        onClick={() => (document.getElementById("profile_picker") as HTMLDialogElement).close()}
+                        onClick={() => profilePickerRef.current?.close()}
                     >
                         ✕
                     </button>

--- a/src/services/matchService.ts
+++ b/src/services/matchService.ts
@@ -1,4 +1,9 @@
+import { PlayerProfile, loadProfiles, saveProfiles } from "./profileService";
+
 import MockData from "./mockDashboardData";
+
+/** Simulates a network delay — replace with real fetch() when API is ready */
+const simulateDelay = (ms = 300) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 export interface MatchDataType {
     id: number;
@@ -67,13 +72,13 @@ export const loadMatchesWithFilter = (filter: MatchFilterPayload = {}): MatchDat
     });
     if (filter.orderBy) {
         result = result.sort((a, b) => {
-            let valA = a[filter.orderBy!];
-            let valB = b[filter.orderBy!];
+            let valA: number | string = a[filter.orderBy!] as string;
+            let valB: number | string = b[filter.orderBy!] as string;
 
-            // ถ้า field เป็น number หรือ date ให้แปลงก่อน
+            // ถ้า field เป็น date ให้แปลงเป็น timestamp ก่อน
             if (filter.orderBy === "createDate" || filter.orderBy === "updateDate") {
-                valA = new Date(valA).getTime();
-                valB = new Date(valB).getTime();
+                valA = new Date(valA as string).getTime();
+                valB = new Date(valB as string).getTime();
             }
 
             // ถ้า orderDirection เป็น desc สลับลำดับ
@@ -84,40 +89,12 @@ export const loadMatchesWithFilter = (filter: MatchFilterPayload = {}): MatchDat
             }
         });
     }
-    console.log("loadMatchesWithFilter result:", result);
     return result;
 };
 
 export const saveHistories = (list: MatchDataType[]) => {
     localStorage.setItem("mudmue_history", JSON.stringify(list));
 };
-
-// export const addHistory = (players: PlayerDataType[], serviceSide: string, winner: string): MatchDataType[] => {
-//     const list = loadHistories();
-//     const maxId = list.length ? Math.max(...list.map((h) => h.id)) : 0;
-//     const newHistory: MatchDataType = {
-//         id: maxId + 1,
-//         player: players,
-//         serviceSide,
-//         winner,
-//         createDate: new Date().toISOString(),
-//         updateDate: new Date().toISOString(),
-//     };
-//     return [...list, newHistory];
-// };
-
-// export const updateHistory = (
-//     id: number,
-//     players: PlayerDataType[],
-//     serviceSide: string,
-//     winner: string
-// ): MatchDataType[] => {
-//     const list = loadHistories();
-//     return list.map((h) => {
-//         const now = new Date().toISOString();
-//         return h.id === id ? { ...h, player: players, serviceSide, winner, updateDate: now } : h;
-//     });
-// };
 
 export const createMatch = (players: PlayerDataType[], serviceSide: string): MatchDataType[] => {
     const list = loadHistories();
@@ -141,11 +118,32 @@ export const updateMatch = (
     winner: string
 ): MatchDataType[] => {
     const list = loadHistories();
-    const newList = list.map((h) => {
-        const now = new Date().toISOString();
-        return h.id === id ? { ...h, player: players, serviceSide, winner, updateDate: now } : h;
-    });
+    const now = new Date().toISOString();
+    const newList = list.map((h) =>
+        h.id === id ? { ...h, player: players, serviceSide, winner, updateDate: now, finishedDate: now } : h
+    );
     saveHistories(newList);
+
+    // อัปเดต win/lose ของ profile
+    if (winner !== "tiled") {
+        const profiles = loadProfiles();
+        const match = newList.find((h) => h.id === id);
+        if (match) {
+            const updatedProfiles = profiles.map((profile: PlayerProfile) => {
+                const playerInMatch = match.player.find((p) => p.uuid === profile.uuid);
+                if (!playerInMatch) return profile;
+                const isWinner = playerInMatch.team === winner;
+                return {
+                    ...profile,
+                    win: isWinner ? profile.win + 1 : profile.win,
+                    lose: !isWinner ? profile.lose + 1 : profile.lose,
+                    updateDate: now,
+                };
+            });
+            saveProfiles(updatedProfiles);
+        }
+    }
+
     return newList;
 };
 
@@ -155,4 +153,31 @@ export const deleteHistory = (list: MatchDataType[], id: number): MatchDataType[
 
 export const getMockMatches = (): MatchDataType[] => {
     return MockData;
+};
+
+// ---------------------------------------------------------------------------
+// Async API layer — simulates HTTP calls (swap for real fetch() when ready)
+// ---------------------------------------------------------------------------
+
+export const loadMatchesWithFilterAsync = async (filter: MatchFilterPayload = {}): Promise<MatchDataType[]> => {
+    await simulateDelay();
+    return loadMatchesWithFilter(filter);
+};
+
+export const createMatchAsync = async (
+    players: PlayerDataType[],
+    serviceSide: string
+): Promise<MatchDataType[]> => {
+    await simulateDelay();
+    return createMatch(players, serviceSide);
+};
+
+export const updateMatchAsync = async (
+    id: number,
+    players: PlayerDataType[],
+    serviceSide: string,
+    winner: string
+): Promise<MatchDataType[]> => {
+    await simulateDelay();
+    return updateMatch(id, players, serviceSide, winner);
 };

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -119,3 +119,14 @@ const genUniqueKey = (existingKeys: string[], length = 6) => {
     } while (existingKeys.includes(key));
     return key;
 };
+
+// ---------------------------------------------------------------------------
+// Async API layer — simulates HTTP calls (swap for real fetch() when ready)
+// ---------------------------------------------------------------------------
+
+const simulateDelay = (ms = 300) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export const loadProfilesAsync = async (): Promise<PlayerProfile[]> => {
+    await simulateDelay();
+    return loadProfiles();
+};

--- a/src/styles/breakpoints.ts
+++ b/src/styles/breakpoints.ts
@@ -1,0 +1,4 @@
+export const breakpoints = {
+    tablet: 900,
+    mobile: 600,
+} as const;

--- a/src/types/player.ts
+++ b/src/types/player.ts
@@ -1,0 +1,7 @@
+export interface PlayerProps {
+    id: number;
+    name: string;
+    displayName?: string;
+    hide: boolean;
+    uuid: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,6 +138,11 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
+"@babel/runtime@^7.21.0":
+  version "7.29.2"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz"
+  integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
+
 "@babel/template@^7.27.2":
   version "7.27.2"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz"
@@ -672,7 +677,7 @@ caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001718:
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001721.tgz"
   integrity sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ==
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -694,6 +699,15 @@ chokidar@^3.6.0:
     readdirp "~3.6.0"
   optionalDependencies:
     fsevents "~2.3.2"
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -721,6 +735,21 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+concurrently@^8.0.0:
+  version "8.2.2"
+  resolved "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz"
+  integrity sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==
+  dependencies:
+    chalk "^4.1.2"
+    date-fns "^2.30.0"
+    lodash "^4.17.21"
+    rxjs "^7.8.1"
+    shell-quote "^1.8.1"
+    spawn-command "0.0.2"
+    supports-color "^8.1.1"
+    tree-kill "^1.2.2"
+    yargs "^17.7.2"
 
 convert-source-map@^2.0.0:
   version "2.0.0"
@@ -782,6 +811,13 @@ daisyui@^4.12.14:
     culori "^3"
     picocolors "^1"
     postcss-js "^4"
+
+date-fns@^2.30.0:
+  version "2.30.0"
+  resolved "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz"
+  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
 
 debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.4.1"
@@ -856,7 +892,7 @@ esbuild@^0.24.0:
     "@esbuild/win32-ia32" "0.24.2"
     "@esbuild/win32-x64" "0.24.2"
 
-escalade@^3.2.0:
+escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
@@ -1071,6 +1107,11 @@ gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
+get-caller-file@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 glob-parent@^5.1.2:
   version "5.1.2"
@@ -1288,6 +1329,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 loose-envify@^1.1.0:
   version "1.4.0"
@@ -1644,6 +1690,11 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
+  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz"
@@ -1699,6 +1750,13 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+rxjs@^7.8.1:
+  version "7.8.2"
+  resolved "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz"
+  integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
+  dependencies:
+    tslib "^2.1.0"
+
 scheduler@^0.23.2:
   version "0.23.2"
   resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz"
@@ -1733,6 +1791,11 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+shell-quote@^1.8.1:
+  version "1.8.3"
+  resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz"
+  integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
+
 signal-exit@^4.0.1:
   version "4.1.0"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
@@ -1748,6 +1811,11 @@ source-map@^0.6.1:
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+spawn-command@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz"
+  integrity sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==
+
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
@@ -1757,7 +1825,16 @@ source-map@^0.6.1:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^4.1.0:
+string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -1841,6 +1918,13 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+supports-color@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
+  dependencies:
+    has-flag "^4.0.0"
+
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
@@ -1895,6 +1979,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tree-kill@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz"
+  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+
 ts-api-utils@^1.3.0:
   version "1.4.3"
   resolved "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz"
@@ -1905,7 +1994,7 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
-tslib@^2.4.0, tslib@2.6.2:
+tslib@^2.1.0, tslib@^2.4.0, tslib@2.6.2:
   version "2.6.2"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
@@ -1988,6 +2077,15 @@ word-wrap@^1.2.5:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^8.1.0:
   version "8.1.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz"
@@ -1996,6 +2094,11 @@ wrap-ansi@^8.1.0:
     ansi-styles "^6.1.0"
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
+
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yallist@^3.0.2:
   version "3.1.1"
@@ -2006,6 +2109,24 @@ yaml@^2.3.4, yaml@^2.4.2:
   version "2.8.0"
   resolved "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz"
   integrity sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==
+
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^17.7.2:
+  version "17.7.2"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
- extract PlayerProps to src/types/player.ts (remove circular dep from spinHelp)
- extract breakpoints to src/styles/breakpoints.ts (shared constant)
- add async API simulation layer (loadMatchesWithFilterAsync, createMatchAsync, updateMatchAsync, loadProfilesAsync) — ready to swap with real fetch()
- replace document.getElementById() dialog control with useRef in MudmueMatchmaker
- add mounted cleanup to useEffect async calls in Dashboard and History
- remove unused currentEditData state from Dashboard and History
- fix TabMenu htmlFor mismatch with radio input id
- fix VSLabel dynamic Tailwind class (use inline style instead of JIT string)
- remove auto-add placeholder players when switching to 4-player mode; show hint "Need X available players (currently Y)" under Random button instead
- fade trophy icon in History view via isDisplay prop on ScoreStepper
- remove console.logs, commented-out dead code throughout mudmue-pick